### PR TITLE
Add CI workflow for lint build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run build
+
+      - run: npm test
+
+      - name: Comment on PR when checks fail
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `⚠️ ${context.workflow} failed. Please review the logs.`
+            });


### PR DESCRIPTION
## Summary
- add a CI workflow triggered on pushes and PRs to main
- install dependencies, run lint, build, and vitest checks, and add failure notification comment on PRs

## Testing
- npm run lint
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc08c9e03c83268b4dc2992d8153da