### PR TITLE
Remove process.env shim from Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ import { resolve } from 'path';
 
 // https://vite.dev/config/
 export default defineConfig({
-  define: { 'process.env': {} },
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- remove the `define: { 'process.env': {} }` shim from the Vite configuration so builds rely on native `import.meta.env`

## Testing
- `npm run build` *(fails: missing dependencies such as class-variance-authority and @radix-ui/react-slot)*

------
https://chatgpt.com/codex/tasks/task_e_68dd13bdc86c8326b50d6d9e7e8451e9